### PR TITLE
chore(renovate): remove redundant prHourlyLimit override

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,6 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "prHourlyLimit": 0,
   "minimumReleaseAge": "3 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
The config already extends the `:prHourlyLimitNone` preset, which sets `prHourlyLimit` to `0`. The explicit `"prHourlyLimit": 0` line was therefore a no-op and is removed here.

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)