### PR TITLE
fix(ci): run release-please with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,29 @@ jobs:
     name: Release PR or release
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    # No GITHUB_TOKEN scopes: release-please runs entirely on the app token
+    # minted below, which carries contents/issues/pull-requests write itself.
+    permissions: {}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Events caused by the default GITHUB_TOKEN never trigger workflows —
+      # GitHub suppresses them to prevent recursion. That is why the release
+      # branch got no CI run and its required checks sat at "Expected" forever,
+      # and why the PR, authored by github-actions[bot], had its `pull_request`
+      # workflows held for maintainer approval. An app installation token is
+      # exempt from that rule, so the push and the PR behave like a human's.
+      - id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
   image:
     name: Tag release image


### PR DESCRIPTION
Events caused by the default `GITHUB_TOKEN` do not trigger workflows — GitHub suppresses them to prevent recursion. Two consequences on release PRs like #521:

- release-please’s push to its release branch fired no `push` event, so CI never ran there. `Typecheck and lint` and `Build and push image` sat at *"Expected — Waiting for status to be reported"* and the PR could not satisfy its required checks. There was nothing to approve — no run had been created at all.
- The PR itself, authored by `github-actions[bot]`, had its `pull_request` workflows held for maintainer approval, re-triggered on every force-push.

An app installation token is exempt from that suppression, so both the branch push and the PR behave like a human’s. The job’s `GITHUB_TOKEN` scopes drop to `permissions: {}` since the app token carries the write access itself.

## Required before merging

The `atgardner-release-please` GitHub App must be installed on this repo with these **repository permissions**:

| Permission | Level |
| --- | --- |
| Metadata | Read-only (mandatory) |
| Contents | Read and write |
| Pull requests | Read and write |
| Issues | Read and write |

No account or organization permissions, and no webhook. `Workflows: write` is deliberately not granted — [release-please-config.json](../blob/main/release-please-config.json) has no `extra-files`, so nothing under `.github/workflows/` is ever modified.

Then add:
- `RELEASE_APP_ID` as a repository **variable**
- `RELEASE_APP_PRIVATE_KEY` as a repository **secret** (the full `.pem` contents)

## Follow-ups

- #521 will not fix itself — it was created by the old token, so its branch still has no CI runs. After this merges the next `Release` run should force-push it with the app token and fire CI. If not, closing it lets release-please recreate it.
- Watch whether `Build and push image` reports `skipped` on the release branch. [ci.yml](../blob/main/.github/workflows/ci.yml#L41) excludes `release-please--*` from that job; a job skipped by a job-level `if:` posts a `skipped` check run, which rulesets count as satisfied. If it instead stays at *Expected*, drop it from the ruleset’s required checks rather than building an image nobody pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)