### PR TITLE
fix(ci): only run CI on branch pushes, not tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,16 @@ name: CI
 
 # Every push to every branch, main included — `main` and `main-<short-sha>` give
 # you something deployable from the tip of main before a release is cut.
+#
+# Branches only. A bare `push` also matches tags, and release-please's `vX.Y.Z`
+# tag would start a run whose metadata is nonsense: `type=ref,event=branch`
+# emits nothing on a tag ref and `prefix={{branch}}-` renders empty, so the
+# image job asks for the invalid tag `:-<sha>` and buildx rejects it. There is
+# nothing to build there anyway — release.yml re-tags the image this workflow
+# already produced for that commit rather than rebuilding it.
 on:
   push:
+    branches: ['**']
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Fallout from #525. A bare `on: push` matches tag pushes as well as branches. That never surfaced before, because release-please created the `vX.Y.Z` tag with the default `GITHUB_TOKEN`, and events from that token trigger no workflows. Now that the tag is pushed with an app installation token, it starts a CI run on the tag ref.

That run cannot succeed. On a tag ref, [metadata-action](../blob/main/.github/workflows/ci.yml#L60-L62) has nothing sensible to emit — `type=ref,event=branch` does not apply, and `prefix={{branch}}-` renders empty — so the image job asked for `ghcr.io/atgardner/osmexport:-f7dc65c`:

```
ERROR: failed to build: invalid tag "ghcr.io/atgardner/osmexport:-f7dc65c": invalid reference format
```

The `release-please--` guard on the image job does not catch it, since `github.ref_name` on a tag is `v2.1.0`.

Scoping to `branches: [**]` matches the intent the header comment already described, and `**` still matches slashed branch names like `renovate/foo`. Nothing is lost by skipping tags: [release.yml](../blob/main/.github/workflows/release.yml#L36-L42) re-tags the image CI already built for that exact commit rather than rebuilding, which is the whole point of that job.

Note the `v2.1.0` release itself was fine — the failed run was only this stray CI-on-tag; `latest`, `v2.1.0` and the chart all published correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)