### PR TITLE
fix(ci): wait before pruning a deleted branch's images

### DIFF
--- a/.github/workflows/prune-branch-images.yml
+++ b/.github/workflows/prune-branch-images.yml
@@ -38,6 +38,23 @@ jobs:
       BRANCH: ${{ inputs.branch || github.event.ref }}
       DRY_RUN: ${{ inputs.dry-run || 'false' }}
     steps:
+      # Merging a PR deletes its branch and pushes to main at the same instant,
+      # so this fires while CI's image push for the merge commit is still in
+      # flight. Both write the same package, and GHCR dedupes layer blobs across
+      # versions: the branch image and the main image are built from the same
+      # tree, so they are the same blobs. Deleting this branch's version drops
+      # the last referrer to layers the in-flight push already decided to skip
+      # uploading, GHCR garbage-collects them, and the manifest then lands on
+      # blobs that are gone — `ERROR: failed to build: unknown blob`.
+      #
+      # Nothing in the registry records that an unfinished push still needs
+      # those blobs, so the only fix is to not overlap. CI on main finishes in
+      # about a minute; three leaves comfortable margin. A manual run is
+      # deliberate and races with nothing, so it skips the wait.
+      - name: Let the merge commit's CI finish pushing
+        if: github.event_name == 'delete'
+        run: sleep 180
+
       - name: Delete versions for the branch
         run: |
           set -euo pipefail


### PR DESCRIPTION
Merging #526 produced the first CI failure on `main` in 649 runs:

```
 > pushing ghcr.io/atgardner/osmexport:main with docker:
ERROR: failed to build: unknown blob
```

Prune deleted exactly what it should have — the log shows one version, `1128700702`, the `fix-ci-skip-tag-pushes` image. The clash is a level below, at layer blobs.

Merging a PR deletes its branch and pushes to main at the same instant, so prune fires while CI's image push for the merge commit is still in flight. Both write the same GHCR package, and GHCR dedupes layer blobs across versions. The branch image and the main image are built from the same tree — the only difference between the two commits is a workflow file, which is not in the image — so their layers are byte-identical, i.e. the same stored blobs.

buildx pushes by HEAD-checking which blobs the registry already has, skipping those uploads, then PUTting the manifest. Timeline:

| Time | Event |
| --- | --- |
| 10:33:44 | prune deletes version `1128700702` |
| 10:33:58 | image push starts; blobs still present (GC is async), so buildx skips uploading them |
| 10:34:12 | manifest PUT — GC has since collected the now-unreferenced blobs → `unknown blob` |

Prune's `latest` / `vX.Y.Z` / bare-semver exclusions cannot help: they protect *versions*, and the main image had no manifest yet. During the window between "skip these blobs" and "submit the manifest", nothing in the registry records that anything needs them. An in-flight push is invisible to a reference count.

So the fix is simply to not overlap. Branch cleanup has no urgency; CI on main finishes in about a minute and three leaves margin. `workflow_dispatch` runs skip the wait, since a manual prune races with nothing.

Considered and rejected: a shared `concurrency` group between prune and the image job. GitHub keeps only one *pending* entry per group and cancels any earlier one, so a third push would silently cancel a queued image build.

Not addressed here: `unknown blob` also occurs as a plain GHCR flake with no prune involved. If it recurs after this, a retry around the build-push step is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)