### PR TITLE
fix(ci): publish release charts without the `v` prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Helm accepts a leading `v`, so the chart version mirrors the image
-          # tag exactly, and --app-version points it at that same image.
+          # A chart version is SemVer, which has no leading `v` — Helm only
+          # tolerates one. It also becomes the OCI tag verbatim, and Helm
+          # resolves an exact `--version` straight to a tag, so publishing
+          # `v2.1.1` makes `--version 2.1.1` a 404. Strip it. This also matches
+          # ci.yml, whose branch charts are already bare `<base>-<slug>-<sha>`.
+          #
+          # --app-version keeps the `v`: it is not a version to be parsed, it
+          # is the image tag values.yaml falls back to, and must match exactly.
           #
           # No `latest` chart: it is not valid SemVer, and CI already publishes
           # `<base>-main` off the tip of main for pre-release deployments.
-          helm package charts/osmexport --version "$TAG" --app-version "$TAG"
-          helm push "osmexport-$TAG.tgz" "$CHARTS"
+          version="${TAG#v}"
+          helm package charts/osmexport --version "$version" --app-version "$TAG"
+          helm push "osmexport-$version.tgz" "$CHARTS"


### PR DESCRIPTION
## The problem

A chart version is SemVer, which has no leading `v` — Helm only tolerates one. It also becomes the OCI tag verbatim, and Helm resolves an exact `--version` straight to a tag, so a chart published as `v2.1.1` 404s when anyone types the version the way SemVer writes it:

```console
$ helm show chart oci://ghcr.io/atgardner/charts/osmexport --version 2.1.1
Error: failed to perform "FetchReference" on source: ghcr.io/atgardner/charts/osmexport:2.1.1: not found

$ helm show chart oci://ghcr.io/atgardner/charts/osmexport --version v2.1.1
Pulled: ghcr.io/atgardner/charts/osmexport:v2.1.1
```

It was also inconsistent with `ci.yml`, which derives `base` from the release-please manifest and therefore already publishes branch charts bare, as `<base>-<slug>-<sha>`. Two tag schemes in one chart repo.

## The change

`release.yml`'s chart job strips the `v` for the chart version and the pushed filename. `--app-version` keeps it — that is not a version to be parsed, it is the image tag `values.yaml` falls back to for `image.tag`, and it must match the published image exactly.

The rule this settles on: `v` is a git-ref decoration. It stays on the tag and the GitHub release, and on the image tag that mirrors them. It comes off anywhere the value is parsed as SemVer.

| Artifact | `v`? |
| --- | --- |
| Git tag / GitHub release | keep |
| Image tag | keep |
| `Chart.yaml` version / OCI chart tag | **drop** |
| `appVersion` | mirrors the image tag, so keeps it |

## Verification

Packaged locally against `TAG=v2.1.2`. The filename matches what `helm push` is handed, and the rendered Deployment still pins the `v`-prefixed image:

```console
$ helm package charts/osmexport --version 2.1.2 --app-version v2.1.2
Successfully packaged chart and saved it to: .../osmexport-2.1.2.tgz

$ helm template t osmexport-2.1.2.tgz | grep image:
          image: "ghcr.io/atgardner/osmexport:v2.1.2"
```

Charts already published as `vX.Y.Z` stay pullable, so nothing breaks — there is just a seam between 2.1.1 and the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)