### PR TITLE
feat(chart): add HTTPRoute and Ingress templates

### DIFF
--- a/charts/osmexport/templates/httproute.yaml
+++ b/charts/osmexport/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "osmexport.fullname" . }}
+  labels:
+    {{- include "osmexport.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "osmexport.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/osmexport/templates/ingress.yaml
+++ b/charts/osmexport/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "osmexport.fullname" . }}
+  labels:
+    {{- include "osmexport.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    {{- if .host }}
+    - host: {{ .host | quote }}
+      http:
+    {{- else }}
+    {{- /* A rule with no host matches any hostname, e.g. reaching the cluster by IP. */}}
+    - http:
+    {{- end }}
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "osmexport.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/osmexport/values.yaml
+++ b/charts/osmexport/values.yaml
@@ -8,7 +8,10 @@ image:
   # matches this chart version. Override only to pin a different image.
   tag: ""
 
+# Secrets in the release namespace holding registry credentials. The GHCR
+# packages are public, so this is only needed if you have made them private.
 imagePullSecrets: []
+#  - name: ghcr-pull-secret
 nameOverride: ""
 fullnameOverride: ""
 
@@ -18,6 +21,40 @@ podLabels: {}
 service:
   type: ClusterIP
   port: 3000
+
+# Gateway API routing. Prefer this over `ingress` on clusters that have the
+# Gateway API CRDs installed; enabling both is allowed but rarely wanted.
+httpRoute:
+  enabled: false
+  annotations: {}
+  # Gateways to attach to. Required when enabled — a route with no parent is
+  # accepted by the API server and then silently routes nothing.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # Omit to serve on every hostname the parent listener accepts.
+  hostnames: []
+  #  - osmexport.example.com
+  # Defaults to one rule sending every path to this chart's Service. Set this
+  # to take over routing entirely — matches, filters, timeouts — in which case
+  # you own the backendRefs too.
+  rules: []
+
+# Traditional Ingress, for clusters without the Gateway API.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: osmexport.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: osmexport-tls
+  #    hosts:
+  #      - osmexport.example.com
 
 # The app serves on 3000 and reads PORT from the environment.
 containerPort: 3000


### PR DESCRIPTION
Adds the two routing options to the chart, plus a discoverability nudge for `imagePullSecrets`.

## HTTPRoute

`gateway.networking.k8s.io/v1`, off by default. `parentRefs`, `hostnames` and `annotations` pass through. `rules` defaults to a single `PathPrefix: /` pointed at this release's Service on `service.port`, so the minimal config is `enabled` plus a parent:

```yaml
httpRoute:
  enabled: true
  parentRefs:
    - name: my-gateway
      namespace: gateway-system
      sectionName: https
  hostnames: [osmexport.example.com]
```

Setting `rules` takes over routing entirely — matches, filters, timeouts — and you own the `backendRefs` at that point.

It is deliberately **not** gated on a `.Capabilities.APIVersions.Has` check. On a cluster without the Gateway API CRDs you want a loud `no matches for kind "HTTPRoute"` at install time, not a release that silently comes up unrouted.

## Ingress

`networking.k8s.io/v1`, also off by default: `className`, `annotations`, `hosts[].paths[]` with `pathType` defaulting to `Prefix`, and `tls`. Conventional shape, minus the dangling `-` that `helm create`'s template renders for a rule with no `host`.

## Why both

Which one you want is a property of the cluster, not the app. Both are independent toggles that cost nothing while off.

## imagePullSecrets

Already worked — [deployment.yaml](../blob/main/charts/osmexport/templates/deployment.yaml) has always rendered it. No template change; it just gets a commented example so pointing the chart at a private GHCR is discoverable from `values.yaml`.

## Verification

`helm lint` passes clean in all four enabled/disabled combinations. The default render is unchanged at Service + Deployment. Both routing objects were rendered and eyeballed, including the hostless catch-all Ingress rule.

CI packages and pushes the chart but never lints or renders it, so none of this is covered by automation yet — a follow-up PR adds `helm lint` / `helm template` and a small `helm-unittest` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)