### PR TITLE
feat(ci): build the image for amd64 and arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # arm64 is built under emulation rather than on an arm runner. The only
+      # thing the Dockerfile compiles is nothing: no dependency in the lockfile
+      # has an install script, and `npm ci --production` unpacks ten pure-JS
+      # packages. Emulating that costs a minute, against a second job, digest
+      # artifacts and a merge step to avoid it.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      # The default docker driver builds one platform at a time. buildx's
+      # container driver is what makes `platforms:` below build both at once.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -74,13 +87,22 @@ jobs:
             type=ref,event=branch
             type=sha,format=short,prefix={{branch}}-
 
+      # Both tags now point at a manifest list rather than a single image, so
+      # `docker pull` resolves per host arch. release.yml needs no change:
+      # `buildx imagetools create` copies the whole index, so the release tag
+      # inherits both platforms.
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # The `npm ci` layer only changes when package-lock.json does, which
+          # is what makes the emulated leg cheap on most pushes.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Nothing used to look at the chart before publishing it — a template that
   # rendered garbage still got packaged and pushed, and you found out at


### PR DESCRIPTION
Both tags now point at an OCI image index instead of a single image, so `docker pull` resolves per host arch. Verified on the branch build:

```console
mediaType: application/vnd.oci.image.index.v1+json
  linux/amd64      sha256:cc2e2127cad3
  linux/arm64      sha256:5e9278cdde26
  unknown/unknown  sha256:84cd7d8ebf0e   ← provenance attestations
  unknown/unknown  sha256:1697bb56f817
```

`node:24-alpine` already publishes both, and nothing in the Dockerfile is arch-specific.

## Why QEMU and not a native arm runner

The usual reason to avoid emulation is compilation, and there is none here: **no package in the lockfile has an install script**, and `npm ci --production` unpacks ten pure-JS dependencies. The alternative — a second job on `ubuntu-24.04-arm`, digest artifacts, and a merge step — is a lot of workflow for a build with nothing to compile.

The measured cost is **39s → 59s** for the image job, and both platforms build in parallel so that is the arm64 leg, not the sum. Layer caching (`type=gha`) takes most of it back on pushes that do not touch `package-lock.json`.

`release.yml` needs no change: `buildx imagetools create` copies the whole index, so release tags inherit both platforms.

## Consequence worth knowing about: the prune workflows

A multi-platform push creates **one tagged index plus four untagged versions** — two platform manifests and two attestation manifests. This push alone:

```
2026-08-13T17:42:16Z  tags=[feat-multi-platform-image-9e5a7e5,feat-multi-platform-image]
2026-08-13T17:42:16Z  tags=[]
2026-08-13T17:42:15Z  tags=[]
2026-08-13T17:42:15Z  tags=[]
2026-08-13T17:42:15Z  tags=[]
```

Both prune workflows select on `.tags | any(test($m))`, and `[] | any(...)` is false. So:

- **Good:** they cannot delete a live index's children, which would break the multi-arch image.
- **Bad:** when they delete a tagged index, its four children survive and keep the blobs alive, so **the prune reclaims nothing**. Untagged versions accumulate about four per push, forever.

I did not fix that here — it is a separate problem and the naive fix is actively dangerous. "Delete all untagged versions" would delete the children of *current* indexes and break the images the cluster pulls. Doing it correctly means walking every tagged index, collecting its referenced child digests, and deleting only untagged versions outside that set.

Two options when you want it, happy to do either:
- Extend the existing prune scripts with that reachability walk — keeps the current explicit style.
- `provenance: false` on the build as a cheap partial mitigation, halving the junk from four to two per push at the cost of the attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)