### PR TITLE
fix(ci): sweep unreferenced package versions by reachability

### DIFF
--- a/.github/workflows/prune-unreferenced-versions.yml
+++ b/.github/workflows/prune-unreferenced-versions.yml
@@ -1,0 +1,139 @@
+name: Prune unreferenced versions
+
+# The other two prune workflows delete versions by tag. That is the only thing
+# they can match on, and it leaves garbage behind in two ways:
+#
+#   - A multi-platform image is an index plus one untagged manifest per
+#     platform, plus one untagged attestation manifest per platform. Deleting
+#     the tagged index does not touch the four children, and while they survive
+#     they keep the layer blobs alive, so the prune reclaims nothing.
+#   - Any moving tag orphans a digest every time it moves. `<base>-main` is
+#     re-pushed on every commit to main, and the chart version it pointed at
+#     before becomes untagged and unreachable on the spot.
+#
+# So this is a mark-and-sweep pass rather than a tag matcher. Every tagged
+# version is a root; walk each root's manifest and collect the digests it
+# references; delete untagged versions that nothing reachable points at.
+#
+# Deliberately not folded into the other two workflows. Reachability is a
+# property of the whole package, not of the branch or the age bracket being
+# pruned — a platform manifest can be shared by two indexes, so "delete the
+# children of the version I just deleted" is not safe. Running the sweep
+# separately means it cleans up after both of them and after anything else that
+# ever orphans a digest.
+on:
+  schedule:
+    # An hour after prune-main-images.yml, so it sweeps what that run orphaned.
+    - cron: '0 5 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Only list what would be deleted
+        required: false
+        default: true
+        type: boolean
+      grace-hours:
+        description: Never delete an untagged version newer than this
+        required: false
+        default: '24'
+        type: string
+
+permissions: {}
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OWNER: atgardner
+      GRACE_HOURS: ${{ inputs.grace-hours || '24' }}
+      DRY_RUN: ${{ inputs.dry-run || 'false' }}
+    steps:
+      - name: Delete unreferenced versions
+        run: |
+          set -euo pipefail
+
+          # buildx pushes the child manifests before the index that references
+          # them, so for a moment mid-push a child is legitimately unreachable.
+          # Deleting one there breaks the push. Nothing in the registry marks a
+          # push as in flight, so the only defence is to ignore anything recent
+          # — the same reasoning behind the sleep in prune-branch-images.yml,
+          # with a much wider margin because this run is never urgent.
+          cutoff=$(date -u -d "$GRACE_HOURS hours ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Grace cut-off: $cutoff (dry-run: $DRY_RUN)"
+
+          sweep() {
+            local api_pkg="$1" repo="$2" label="$3"
+            echo "--- $label ($repo)"
+
+            local versions token roots reachable targets count
+            versions=$(gh api --paginate \
+              "/users/$OWNER/packages/container/$api_pkg/versions" \
+              --jq '.[] | {id, digest: .name, tags: (.metadata.container.tags // []), updated_at}' \
+              | jq -s '.')
+            echo "    read $(printf '%s' "$versions" | jq 'length') version(s)"
+
+            # The packages API knows nothing about manifest contents, so the
+            # walk has to read them from the registry itself. A pull-scoped
+            # token off the same GITHUB_TOKEN is enough.
+            token=$(curl -fsSL -u "$OWNER:$GH_TOKEN" \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:$repo:pull" \
+              | jq -r '.token')
+
+            roots=$(printf '%s' "$versions" | jq -r '.[] | select(.tags | length > 0) | .digest')
+
+            # Any failure below aborts the run, on purpose. A root whose
+            # manifest cannot be read looks childless, which would make its
+            # children look garbage and delete a live image. Reading nothing is
+            # always safer than reading half.
+            reachable=$(mktemp)
+            local digest children
+            while IFS= read -r digest; do
+              [ -n "$digest" ] || continue
+              printf '%s\n' "$digest" >> "$reachable"
+              children=$(curl -fsSL -H "Authorization: Bearer $token" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json' \
+                -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+                -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+                -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+                "https://ghcr.io/v2/$repo/manifests/$digest" \
+                | jq -r '(.manifests // [])[].digest')
+              [ -z "$children" ] || printf '%s\n' "$children" >> "$reachable"
+            done <<< "$roots"
+            sort -u -o "$reachable" "$reachable"
+            echo "    $(printf '%s' "$roots" | grep -c . || true) root(s) reach $(grep -c . "$reachable" || true) digest(s)"
+
+            targets=$(printf '%s' "$versions" | jq -c \
+              --arg cutoff "$cutoff" --rawfile reach "$reachable" '
+              ($reach | split("\n") | map(select(length > 0))) as $keep
+              | map(select(
+                  (.tags | length) == 0
+                  and ((.digest | IN($keep[])) | not)
+                  and (.updated_at < $cutoff)
+                ))')
+            rm -f "$reachable"
+
+            count=$(printf '%s' "$targets" | jq 'length')
+            echo "    unreferenced and past grace: $count"
+            printf '%s' "$targets" | jq -r '.[] | "      id=\(.id) \(.updated_at) \(.digest)"'
+
+            if [ "$count" -eq 0 ] || [ "$DRY_RUN" = "true" ]; then
+              return 0
+            fi
+
+            local id
+            for id in $(printf '%s' "$targets" | jq -r '.[].id'); do
+              echo "    deleting $id"
+              gh api --method DELETE \
+                "/users/$OWNER/packages/container/$api_pkg/versions/$id"
+            done
+          }
+
+          sweep "osmexport" "$OWNER/osmexport" "images"
+          sweep "charts%2Fosmexport" "$OWNER/charts/osmexport" "charts"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run — no deletions performed."
+          fi


### PR DESCRIPTION
Follow-up to #534. The other two prune workflows match on tags — all the packages API exposes — which leaves garbage behind two ways:

- **Multi-platform images.** An index plus an untagged manifest per platform plus an untagged attestation per platform. Deleting the tagged index leaves four children holding the layer blobs alive, so the prune reclaims nothing.
- **Any moving tag**, which orphans a digest every time it moves. `<base>-main` is re-pushed on every commit to main and the chart it pointed at before goes untagged and unreachable on the spot. **This one predates multi-arch** — the charts package already has 11 orphans sitting in it today.

## Mark and sweep

Every tagged version is a root. Walk each root's manifest, collect the digests it references, delete untagged versions nothing reachable points at.

Kept as its own workflow rather than folded into the other two, because reachability is a property of the whole package rather than the branch or age bracket being pruned — two indexes can share a platform manifest, so "delete the children of the version I just deleted" is not safe.

## Verified against the live registry

Ran the script **extracted verbatim from the YAML** in dry-run.

**Live children survive.** The four untagged image versions right now are exactly the amd64 manifest, the arm64 manifest and their two attestations. Even at a one-hour grace, images target zero:

```
--- images (atgardner/osmexport)
    read 20 version(s)
    16 root(s) reach 20 digest(s)
    unreferenced and past grace: 0
```

**Real garbage is found.** Same run, charts:

```
--- charts (atgardner/charts/osmexport)
    read 29 version(s)
    18 root(s) reach 18 digest(s)
    unreferenced and past grace: 11
      id=1130065582 2026-08-13T16:59:20Z sha256:15875a9f…
      … 10 more
```

**An unreadable root aborts the run.** This is the dangerous failure: a root that 404s looks childless, which would make its children look like garbage and delete a live image. Reproduced with a forced 404 — the script exits 56 before reaching any deletion, rather than sweeping on partial knowledge.

## The grace window

buildx uploads child manifests *before* the index that references them, so mid-push a child is genuinely unreachable. Nothing in the registry marks a push as in flight, so the only defence is ignoring anything recent — same reasoning as the `sleep 180` in `prune-branch-images.yml`, with a much wider margin since this run is never urgent. Default 24h, overridable on dispatch.

## Before merging

Scheduled runs delete for real (`dry-run` defaults true on dispatch, false on schedule — matching the existing workflows). Worth one manual dispatch with dry-run on first, to see the 11 chart orphans listed before the weekly cron takes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)