### PR TITLE
feat(logging): cap the log files by size and count

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,14 +2,31 @@ import {Logger, createLogger, format, transports} from 'winston';
 
 const {combine, colorize, errors, json, simple, timestamp} = format;
 
+/*
+ * `maxsize` on its own only rolls over to a new file, so the disk still fills
+ * up in 20MB pieces. `maxFiles` is what unlinks the oldest, and `tailable`
+ * keeps the newest entries in the unsuffixed name instead of moving the live
+ * log to a new number on every rotation. Each transport is capped at
+ * maxsize * maxFiles, so this pair costs 200MB at worst.
+ */
+const fileOptions = {
+  maxsize: 20 * 1024 * 1024,
+  maxFiles: 5,
+  tailable: true,
+};
+
 const logger = createLogger({
   level: 'info',
   format: combine(timestamp(), errors({stack: true}), json()),
   transports: [
     // Write all errors to a dedicated file
-    new transports.File({filename: 'logs/error.log', level: 'error'}),
+    new transports.File({
+      filename: 'logs/error.log',
+      level: 'error',
+      ...fileOptions,
+    }),
     // Write all logs (info, warn, error) to a combined file
-    new transports.File({filename: 'logs/combined.log'}),
+    new transports.File({filename: 'logs/combined.log', ...fileOptions}),
   ],
 });
 


### PR DESCRIPTION
## Why

The winston file transports were unbounded. That mattered less when the logs died with the pod, but #539 lets them live on a PersistentVolume — and an unbounded logger fills whatever volume you give it.

## Why `maxsize` alone is not enough

It only rolls over to a new file. Without `maxFiles`, the deletion path returns immediately:

```js
_checkMaxFilesIncrementing(ext, basename, callback) {
  if (!this.maxFiles || this._created < this.maxFiles) {
    return setImmediate(callback);   // nothing unlinked
  }
```

So you get `combined.log`, `combined1.log`, `combined2.log`, … forever. The disk still fills, just in 20MB pieces. `maxsize` caps each *file*, not the total.

`tailable: true` additionally keeps the newest entries in the unsuffixed name. Without it the live log moves to a new number on every rotation (`_getFile()` returns `${basename}${_created}${ext}`), so nothing can tail a stable path. Note that `tailable` without `maxFiles` hits `if (!this.maxFiles) return;` at file.js:734, which never invokes its callback and stalls the rotation — the two options only work as a pair.

## Result

`maxsize: 20MB`, `maxFiles: 5`, `tailable: true` on both transports — at worst 200MB total, against the chart's 1Gi default claim.

## Testing

`npm run typecheck` and `npm run lint:ci` pass. Rotation verified directly with a scaled-down `maxsize: 2048`, writing 300 lines:

```
combined.log    600   <- newest (line 0299)
combined1.log  2100   <- line 0273
combined2.log  2100
combined3.log  2100
combined4.log  2100   <- oldest surviving (line 0210)
```

Lines 0000-0209 are unlinked, the file count holds at five, and `combined.log` stays the live one.

## Two caveats

- **The cap is approximate.** Rotated files landed at 2100 bytes against a 2048 limit, because winston rotates *after* the write that crosses the threshold. Budget slack rather than treating `maxsize * maxFiles` as a hard ceiling.
- **No time-based expiry.** Files only age out when traffic pushes them out, so a quiet deployment can hold entries from months ago. Deliberate — `winston-daily-rotate-file` is the option if that ever matters, and it was not worth a dependency here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)