### PR TITLE
feat(metrics): export prometheus metrics on a separate port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ ADD --chown=osmexport:osmexport src /app/src/
 
 WORKDIR /app
 
-EXPOSE 3000
+# 3000 is the API. 9091 serves /metrics on a separate listener, so that the
+# chart's Ingress and HTTPRoute — which route every path to 3000 — cannot
+# publish it. Documented here because the image serves it by default; the
+# chart opts out with METRICS_ENABLED unless metrics.enabled is set.
+EXPOSE 3000 9091
 
 # Node 24 strips the types natively; types/ is compile-time only and never copied.
 CMD ["node", "index.ts"]

--- a/charts/osmexport/ci/all-values.yaml
+++ b/charts/osmexport/ci/all-values.yaml
@@ -28,6 +28,19 @@ service:
 
 containerPort: 8080
 
+# The ServiceMonitor is the chart's second CRD-backed object, so this is what
+# makes kubeconform check it against the monitoring.coreos.com schema.
+metrics:
+  enabled: true
+  port: 9099
+  scrapeAnnotations: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
+    labels:
+      release: kube-prometheus-stack
+
 # Both at once. They are independent in the templates, and enabling both is the
 # only way one render reaches every object the chart can produce. The HTTPRoute
 # is the reason kubeconform needs a CRD schema source in ci.yml.

--- a/charts/osmexport/templates/deployment.yaml
+++ b/charts/osmexport/templates/deployment.yaml
@@ -12,7 +12,11 @@ spec:
       {{- include "osmexport.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- $scrapeAnnotations := dict }}
+      {{- if and .Values.metrics.enabled .Values.metrics.scrapeAnnotations }}
+      {{- $scrapeAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" "/metrics" "prometheus.io/port" (.Values.metrics.port | toString) }}
+      {{- end }}
+      {{- with merge (deepCopy (.Values.podAnnotations | default dict)) $scrapeAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -37,10 +41,22 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.containerPort | quote }}
+            # Set either way rather than only when enabled: the app defaults to
+            # serving metrics when this is unset, so leaving it off would run a
+            # listener the chart never declared or exposed.
+            - name: METRICS_ENABLED
+              value: {{ .Values.metrics.enabled | quote }}
+            - name: METRICS_PORT
+              value: {{ .Values.metrics.port | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/osmexport/templates/service.yaml
+++ b/charts/osmexport/templates/service.yaml
@@ -12,5 +12,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    # Named `metrics` because the ServiceMonitor selects the port by this name.
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "osmexport.selectorLabels" . | nindent 4 }}

--- a/charts/osmexport/templates/servicemonitor.yaml
+++ b/charts/osmexport/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "osmexport.fullname" . }}
+  labels:
+    {{- include "osmexport.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "osmexport.selectorLabels" . | nindent 6 }}
+  # Restricting this to the release namespace keeps the ServiceMonitor from
+  # matching a same-labelled Service in another namespace.
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    # By port name, not number, so it follows metrics.port automatically.
+    - port: metrics
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/osmexport/tests/deployment_test.yaml
+++ b/charts/osmexport/tests/deployment_test.yaml
@@ -56,6 +56,87 @@ tests:
           path: spec.template.spec.containers[0].ports[0].name
           value: http
 
+  # METRICS_ENABLED is what actually stops the listener — the app serves
+  # metrics when it is unset, so an unset variable here would leave a disabled
+  # release still listening on a port the chart never declared or exposed.
+  # That is why it is rendered either way rather than only when metrics are on.
+  - it: declares no metrics port by default and tells the app to stay quiet
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].ports
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[1]
+          value:
+            name: METRICS_ENABLED
+            value: "false"
+
+  - it: drives the metrics port and env vars from metrics.port when enabled
+    set:
+      metrics.enabled: true
+      metrics.port: 9099
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1]
+          value:
+            name: METRICS_ENABLED
+            value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[2]
+          value:
+            name: METRICS_PORT
+            value: "9099"
+      - equal:
+          path: spec.template.spec.containers[0].ports[1]
+          value:
+            name: metrics
+            containerPort: 9099
+            protocol: TCP
+
+  # The port in the annotation has to track metrics.port. Hardcoding it in
+  # values.yaml renders a scrape target that is valid YAML, gets discovered,
+  # and times out against a closed port.
+  - it: annotates the pod for annotation-based scraping, using metrics.port
+    set:
+      metrics.enabled: true
+      metrics.scrapeAnnotations: true
+      metrics.port: 9099
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            prometheus.io/scrape: "true"
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9099"
+
+  - it: merges the scrape annotations with the user's podAnnotations
+    set:
+      metrics.enabled: true
+      metrics.scrapeAnnotations: true
+      podAnnotations:
+        team: maps
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["team"]
+          value: maps
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: adds no scrape annotations by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  # The two flags are opt-in independently, so asking to be scraped without
+  # exposing the port must not annotate a target nothing can reach.
+  - it: omits the scrape annotations unless the metrics port is exposed too
+    set:
+      metrics.scrapeAnnotations: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
   - it: omits empty optional blocks rather than emitting nulls
     asserts:
       - notExists:

--- a/charts/osmexport/tests/service_test.yaml
+++ b/charts/osmexport/tests/service_test.yaml
@@ -29,3 +29,27 @@ tests:
           value:
             app.kubernetes.io/name: osmexport
             app.kubernetes.io/instance: test-release
+
+  # The ServiceMonitor selects this port by name, so the name is load-bearing
+  # in a way `helm lint` cannot see.
+  - it: exposes the metrics port by name alongside http when enabled
+    set:
+      metrics.enabled: true
+      metrics.port: 9099
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            port: 9099
+            targetPort: metrics
+            protocol: TCP
+            name: metrics
+
+  - it: exposes only http by default
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].name
+          value: http

--- a/charts/osmexport/tests/servicemonitor_test.yaml
+++ b/charts/osmexport/tests/servicemonitor_test.yaml
@@ -1,0 +1,97 @@
+---
+# A ServiceMonitor that renders but selects nothing is the failure mode here:
+# it installs cleanly, Prometheus accepts it, and no series ever appear. So
+# assert the selector and the endpoint port against the same literals the
+# Service and Deployment use.
+suite: servicemonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: test-release
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # The other half of the `and` guard: metrics exposed, but no one asked the
+  # operator to scrape them.
+  - it: renders nothing when metrics are on but the serviceMonitor is not
+    set:
+      metrics.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # The CRD is not installed on most clusters, so rendering a ServiceMonitor
+  # for someone who only turned metrics on would fail their install outright.
+  - it: renders nothing when metrics are off, even if the serviceMonitor is on
+    set:
+      metrics.enabled: false
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: selects this release's pods and scrapes the named metrics port
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: osmexport
+            app.kubernetes.io/instance: test-release
+      # By name, not number — a numeric port here would silently stop matching
+      # the moment metrics.port changed.
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: NAMESPACE
+
+  # Empty means "inherit the Prometheus instance's defaults". Rendering the
+  # keys with empty values instead sets a zero interval, which the operator
+  # rejects at reload time rather than at install time.
+  - it: omits interval and scrapeTimeout when they are empty
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].interval
+      - notExists:
+          path: spec.endpoints[0].scrapeTimeout
+
+  - it: renders interval, scrapeTimeout and extra labels when set
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.interval: 30s
+      metrics.serviceMonitor.scrapeTimeout: 10s
+      metrics.serviceMonitor.labels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 10s
+      # Merged into the chart's own labels, not replacing them — the operator
+      # selects on this one while app.kubernetes.io/* stays intact.
+      - equal:
+          path: metadata.labels["release"]
+          value: kube-prometheus-stack
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: osmexport

--- a/charts/osmexport/values.yaml
+++ b/charts/osmexport/values.yaml
@@ -59,6 +59,38 @@ ingress:
 # The app serves on 3000 and reads PORT from the environment.
 containerPort: 3000
 
+# Prometheus metrics, served on their own listener separate from the API —
+# `ingress` and `httpRoute` send every path to the `http` port, so a /metrics
+# route there would be published to the internet along with the exporter.
+#
+# Off by default: the app exports nothing about itself that it needs in order
+# to work, so this is opt-in like every other optional block in this chart.
+# Enabling it sets METRICS_ENABLED on the container, declares the port and
+# adds it to the Service.
+metrics:
+  enabled: false
+  # Read by the app as METRICS_PORT, and the port the Service exposes.
+  port: 9091
+  # Adds the prometheus.io/{scrape,path,port} pod annotations, for a Prometheus
+  # that discovers targets by annotation. The port is rendered from
+  # metrics.port above, so the two cannot drift.
+  #
+  # Also opt-in, and deliberately separate from `enabled`: exposing the port
+  # changes nothing on its own, but these annotations make a Prometheus this
+  # chart does not own start ingesting series and spending its storage. Worth
+  # asking for explicitly.
+  scrapeAnnotations: false
+  # For the Prometheus Operator instead. Needs the ServiceMonitor CRD, so it
+  # is off by default; enabling it without the CRD fails the install.
+  serviceMonitor:
+    enabled: false
+    # Empty means inherit the Prometheus instance's own defaults.
+    interval: ""
+    scrapeTimeout: ""
+    # Most operator deployments only select ServiceMonitors carrying a
+    # particular label — check `spec.serviceMonitorSelector` on your Prometheus.
+    labels: {}
+
 # Winston writes error.log and combined.log under the image's WORKDIR, so by
 # default they live in the container filesystem and are lost when the pod is
 # replaced. Enable this to keep them on a PersistentVolume instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lodash": "^4.18.1",
         "moment": "^2.30.1",
         "osmtogeojson": "^3.0.0-beta.5",
+        "prom-client": "^15.1.3",
         "slug": "^12.0.0",
         "winston": "^3.19.0",
         "yargs": "^18.0.0"
@@ -275,6 +276,15 @@
       },
       "bin": {
         "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1224,6 +1234,12 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -3457,6 +3473,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -4002,6 +4031,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
     "osmtogeojson": "^3.0.0-beta.5",
+    "prom-client": "^15.1.3",
     "slug": "^12.0.0",
     "winston": "^3.19.0",
     "yargs": "^18.0.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import {BadRequestError, getRelation, parseRelationRequest} from './osm2gpx.ts';
 import express, {type ErrorRequestHandler, type RequestHandler} from 'express';
+import {metricsMiddleware, startMetricsServer} from './metrics.ts';
 import {getLogger} from './logger.ts';
 import slug from 'slug';
 
@@ -67,6 +68,8 @@ const errorHandler: ErrorRequestHandler = (error, req, res, next) => {
  *JMT - http://localhost:3000/osm2gpx?relationId=1244828&markerDiff=1609.34&reverse=1&segmentLimit=0
  * 6148296 - ramon crater
  */
+// Ahead of the routes, so unmatched paths and error responses are counted too.
+app.use(metricsMiddleware);
 app.get('/osm2gpx', handler);
 app.use(errorHandler);
 
@@ -74,3 +77,5 @@ const port = process.env.PORT || 3000;
 app.listen(port, () => {
   logger.info(`OSMExport listening on port ${port}!`);
 });
+
+startMetricsServer();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,141 @@
+import {Histogram, Registry, collectDefaultMetrics} from 'prom-client';
+import express, {type RequestHandler} from 'express';
+import {getLogger} from './logger.ts';
+
+const logger = getLogger('metrics');
+
+/*
+ * A dedicated registry rather than prom-client's global one, so importing this
+ * module from the CLI entrypoint cannot collide with anything else and tests
+ * can build their own. `collectDefaultMetrics` adds the process and Node
+ * runtime series — event loop lag, GC pauses, heap and handle counts — which
+ * are the only signals that distinguish "Overpass is slow" from "we are".
+ */
+export const registry = new Registry();
+
+collectDefaultMetrics({register: registry});
+
+/*
+ * Every duration bucket set below is in seconds and skewed long on purpose.
+ * A request here is dominated by one or two Overpass round trips, so the
+ * library defaults (which top out at 10s) would pile most real traffic into
+ * +Inf and make the histogram unable to answer anything.
+ */
+const httpRequestDuration = new Histogram({
+  name: 'osmexport_http_request_duration_seconds',
+  help: 'Duration of HTTP requests, by matched route and response status',
+  labelNames: ['route', 'status'],
+  buckets: [0.05, 0.25, 1, 2.5, 5, 10, 20, 30, 60, 120],
+  registers: [registry],
+});
+
+const overpassRequestDuration = new Histogram({
+  name: 'osmexport_overpass_request_duration_seconds',
+  help: 'Duration of outbound Overpass API queries, by query kind and outcome',
+  labelNames: ['query', 'outcome'],
+  buckets: [0.5, 1, 2.5, 5, 10, 20, 30, 60],
+  registers: [registry],
+});
+
+const gpxSizeBytes = new Histogram({
+  name: 'osmexport_gpx_size_bytes',
+  help: 'Size of generated GPX documents',
+  // The Israel National Trail, one of the largest relations exported, is ~2MB.
+  buckets: [10e3, 100e3, 500e3, 2e6, 8e6, 32e6],
+  registers: [registry],
+});
+
+const relationPoints = new Histogram({
+  name: 'osmexport_relation_points',
+  help: 'Number of coordinates in an exported relation',
+  buckets: [100, 1e3, 5e3, 20e3, 80e3, 320e3],
+  registers: [registry],
+});
+
+/*
+ * No separate request counter: a histogram already exports `_count` per label
+ * set, so rate() over `osmexport_http_request_duration_seconds_count` gives
+ * throughput and the `status` label gives the 400-vs-500 split.
+ */
+export const metricsMiddleware: RequestHandler = (req, res, next) => {
+  const stop = httpRequestDuration.startTimer();
+  /*
+   * `close` rather than `finish`, because an export that outlives the client's
+   * patience is exactly the case worth seeing: `finish` never fires when the
+   * connection is dropped mid-request, so those would vanish from the
+   * histogram instead of showing up as a slow abort.
+   */
+  res.on('close', () => {
+    /*
+     * The matched route pattern, never `req.path` — this app 404s anything
+     * else, and labelling by raw path would let a crawler mint an unbounded
+     * number of series. Express types `route` as `any`, hence the assertion.
+     */
+    const route = req.route as {path?: string} | undefined;
+    stop({
+      route: route?.path ?? 'unmatched',
+      status: res.writableEnded ? res.statusCode : 'aborted',
+    });
+  });
+  next();
+};
+
+export async function observeOverpassQuery<T>(
+  query: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const stop = overpassRequestDuration.startTimer({query});
+  try {
+    const result = await run();
+    stop({outcome: 'success'});
+    return result;
+  } catch (error) {
+    stop({outcome: 'error'});
+    throw error;
+  }
+}
+
+export function observeRelationPoints(count: number): void {
+  relationPoints.observe(count);
+}
+
+export function observeGpxSize(gpx: string): void {
+  // Byte length, not string length — GPX carries non-ASCII relation names.
+  gpxSizeBytes.observe(Buffer.byteLength(gpx));
+}
+
+/*
+ * Served on its own port, not as a route on the main app. The chart's Ingress
+ * and HTTPRoute both send every path to the `http` port, so a `/metrics` route
+ * there would be published to the internet along with the exporter.
+ *
+ * `METRICS_ENABLED=false` turns the listener off outright, which is what the
+ * chart sets when `metrics.enabled` is false. Unset means on, so a local run
+ * or a bare `docker run` still exposes metrics without extra ceremony. The
+ * port cannot double as the switch — `METRICS_PORT=0` binds a random free
+ * port in Node rather than meaning "off".
+ */
+export function startMetricsServer(): void {
+  if (process.env.METRICS_ENABLED === 'false') {
+    /*
+     * Logged rather than silent: "no metrics" is otherwise indistinguishable
+     * from a crashed listener when you go looking for the endpoint.
+     */
+    logger.info('metrics disabled by METRICS_ENABLED');
+    return;
+  }
+
+  const port = Number(process.env.METRICS_PORT) || 9091;
+  const metricsApp = express();
+  metricsApp.get('/metrics', async (req, res, next) => {
+    try {
+      res.set('Content-Type', registry.contentType);
+      res.send(await registry.metrics());
+    } catch (error) {
+      next(error);
+    }
+  });
+  metricsApp.listen(port, () => {
+    logger.info(`metrics listening on port ${port}`);
+  });
+}

--- a/src/osm/osmApi.ts
+++ b/src/osm/osmApi.ts
@@ -1,38 +1,53 @@
+import {observeOverpassQuery} from '../metrics.ts';
+
 interface OverpassError {
   error?: string;
 }
 
-async function overpassQuery(query: string) {
-  const body = `[out:json][timeout:25];${query}`;
-  const result = await fetch('http://overpass-api.de/api/interpreter', {
-    method: 'POST',
-    body,
-    /*
-     * Overpass rejects undici's default `User-Agent: node` with a 406.
-     * node-fetch used to send its own UA, so this only surfaced once it went.
-     */
-    headers: {'User-Agent': 'OSMExport/2.0.1'},
-  });
-  if (!result.ok) {
-    const errorBody = (await result.json().catch(() => ({}))) as OverpassError;
-    throw new Error(
-      errorBody.error || `Request failed with status ${result.status}`,
-    );
-  }
+/*
+ * `kind` is what labels the metric — the query text itself embeds the relation
+ * id, so using it would mint a new series per relation exported.
+ */
+function overpassQuery(kind: string, query: string) {
+  return observeOverpassQuery(kind, async () => {
+    const body = `[out:json][timeout:25];${query}`;
+    const result = await fetch('http://overpass-api.de/api/interpreter', {
+      method: 'POST',
+      body,
+      /*
+       * Overpass rejects undici's default `User-Agent: node` with a 406.
+       * node-fetch used to send its own UA, so this only surfaced once it went.
+       */
+      headers: {'User-Agent': 'OSMExport/2.0.1'},
+    });
+    if (!result.ok) {
+      const errorBody = (await result
+        .json()
+        .catch(() => ({}))) as OverpassError;
+      throw new Error(
+        errorBody.error || `Request failed with status ${result.status}`,
+      );
+    }
 
-  return result.json();
+    return result.json();
+  });
 }
 
 export function fetchRelation(relationId: number) {
-  return overpassQuery(`
+  return overpassQuery(
+    'relation',
+    `
     relation(${relationId});
     (._;>;);
     out body meta;
-  `);
+  `,
+  );
 }
 
 export function fetchNodesInRelation(relationId: number) {
-  return overpassQuery(`
+  return overpassQuery(
+    'nodes',
+    `
     relation(${relationId}) -> .r;
     way(r.r) -> .w;
     node(w.w) -> .n;
@@ -42,5 +57,6 @@ export function fetchNodesInRelation(relationId: number) {
       .r;
     )->.all;
     .all out body meta;
-  `);
+  `,
+  );
 }

--- a/src/osm2gpx.ts
+++ b/src/osm2gpx.ts
@@ -5,6 +5,7 @@ import type {
   Point,
   Position,
 } from 'geojson';
+import {observeGpxSize, observeRelationPoints} from './metrics.ts';
 import LatLon from 'geodesy/latlon-ellipsoidal-vincenty.js';
 import _ from 'lodash';
 import {getFullRelation} from './osm/osmWrapper.ts';
@@ -226,13 +227,24 @@ export async function getRelation(
     relation.geometry.coordinates.reverse();
   }
 
+  /*
+   * Point count is the input size that actually drives how long the rest of
+   * this takes — `addMarkers` runs a Vincenty solution per point — so it is
+   * what makes a slow export explainable rather than just slow.
+   */
+  observeRelationPoints(
+    waysOf(relation.geometry).reduce((total, way) => total + way.length, 0),
+  );
   const markers = addMarkers(relation, markerDiff);
   const {
     properties: {name, 'name:en': nameEn = name, timestamp},
   } = relation;
   const fileName = `${nameEn}-${moment(timestamp).format('YY-MM-DD')}.gpx`;
+  // Not named `gpx`; that would shadow the builder module imported above.
+  const gpxXml = createGpx(relation, markers, segmentLimit);
+  observeGpxSize(gpxXml);
   return {
     fileName,
-    gpx: createGpx(relation, markers, segmentLimit),
+    gpx: gpxXml,
   };
 }


### PR DESCRIPTION
Adds prom-client behind an opt-in chart flag. Metrics are served on their own listener, not as a route on the API, and the whole thing is off by default.

## Metrics

Node runtime defaults (event loop lag, GC pauses, heap, handles), plus:

| Metric | Labels |
|---|---|
| `osmexport_http_request_duration_seconds` | `route`, `status` |
| `osmexport_overpass_request_duration_seconds` | `query`, `outcome` |
| `osmexport_gpx_size_bytes` | — |
| `osmexport_relation_points` | — |

No separate request counter: the histogram's `_count` gives throughput and `status` gives the 400-vs-500 split.

## Decisions worth a second look

**prom-client over OpenTelemetry.** The one thing OTel gives free here — auto-instrumented outbound HTTP — is twenty lines around the two Overpass calls, and the metrics that explain a slow export are custom either way. prom-client is one dependency with no preload hook, which is the part of OTel most likely to fight ESM plus `node index.ts` type stripping.

**Its own port.** `ingress` and `httpRoute` both send every path to the `http` port, so a `/metrics` route there would be public.

**Long buckets.** A Ramon crater export measured 2.040s total against 2.014s in Overpass. The library defaults top out at 10s and would put most real traffic in `+Inf`.

**`res.on('close')`, not `'finish'`.** Exports outlive client patience often enough that aborted requests are worth a `status=\"aborted\"` label; `finish` never fires for them.

**Both chart flags off by default.** `metrics.enabled` renders `METRICS_ENABLED` on the container either way, so it stops the listener rather than leaving it running on a port nothing declares. `metrics.scrapeAnnotations` is separately opt-in — exposing a ClusterIP port is inert, but the annotations make a Prometheus this chart doesn't own start spending storage.

Unset `METRICS_ENABLED` means on, so local runs and a bare `docker run` still expose metrics; the chart never leaves it unset.

## Verification

- All three env states exercised against the running app: `false` refuses connections on the metrics port while the API still serves, `true` exposes 95 series, unset returns 200.
- Live export checked end to end — `osmexport_gpx_size_bytes_sum` matched the downloaded byte count exactly, and a `curl -m 1` against the Israel National Trail recorded `status="aborted"` at 1.005s.
- CLI still exits in ~2s, so the registry leaves no lingering handles.
- `helm lint --strict`, kubeconform against real CRD schemas on both the default and `ci/all-values.yaml` renders, and 56 chart unit tests. The ServiceMonitor's `and` guard is covered from both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)