### PR TITLE
fix(logging): write to stdout in production

### DIFF
--- a/charts/osmexport/values.yaml
+++ b/charts/osmexport/values.yaml
@@ -94,6 +94,9 @@ metrics:
 # Winston writes error.log and combined.log under the image's WORKDIR, so by
 # default they live in the container filesystem and are lost when the pod is
 # replaced. Enable this to keep them on a PersistentVolume instead.
+#
+# The same lines also go to stdout as JSON, so if a log collector is already
+# shipping them off the node this buys little beyond a second copy.
 persistence:
   enabled: false
   # Bind a PVC you manage yourself. Every provisioning field below is ignored

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -30,13 +30,26 @@ const logger = createLogger({
   ],
 });
 
-if (process.env.NODE_ENV !== 'production') {
-  logger.add(
-    new transports.Console({
-      format: combine(colorize(), simple()),
-    }),
-  );
-}
+/*
+ * Kubernetes collects a container's logs by capturing what it writes to
+ * stdout, so this transport is what makes the app visible to `kubectl logs`
+ * and to any log collector at all. Gating it on a non-production environment
+ * left the deployed pods writing nothing to stdout: the files above are only
+ * reachable by exec'ing into the pod, and they go with it unless the chart's
+ * PersistentVolume is enabled.
+ *
+ * Production inherits the logger's own JSON format — one object per line,
+ * stack traces included, which is what a collector parses. Errors stay on
+ * stdout with everything else rather than splitting to stderr; the two
+ * streams can interleave out of order once a collector merges them back, and
+ * `level` is already a field to query on.
+ */
+const consoleOptions =
+  process.env.NODE_ENV === 'production'
+    ? {}
+    : {format: combine(colorize(), simple())};
+
+logger.add(new transports.Console(consoleOptions));
 
 export function getLogger(label: string): Logger {
   return logger.child({label});


### PR DESCRIPTION
Deployed pods currently write **nothing** to stdout. [logger.ts](../blob/main/src/logger.ts) adds the Console transport only when `NODE_ENV !== 'production'`, and the Dockerfile sets `ENV NODE_ENV production`, so `kubectl logs` returns empty and no log collector can see this app at all.

Verified before the change — a production-mode run serving a request produced 0 bytes on stdout and 0 on stderr, with everything going to `logs/combined.log`.

## The change

The Console transport is now added in every environment:

- **Production** inherits the logger's own JSON format — one object per line, stack trace as a single escaped field, so a collector never has to reassemble a multiline trace.
- **Development** keeps the colorized `simple()` format, unchanged.

Errors stay on stdout rather than splitting to stderr. The two streams can interleave out of order once something merges them back, and `level` is already a field to query on.

File transports and their rotation caps are untouched — this makes the logs reachable from outside the pod, it doesn't replace them.

## Why now

Prometheus can't store logs, so metrics ([#542](https://github.com/ATGardner/OSMExport/pull/542)) don't help here and neither would switching instrumentation libraries. Kubernetes log collection works by tailing what the container writes to stdout, which means this transport is the prerequisite for *any* collector — Alloy, Fluent Bit, Vector, or an OTel Collector — regardless of which one gets picked later.

It also changes how the PVC reads: `persistence` is now a second copy of logs that already leave the node, rather than the only durable copy. `values.yaml` notes that so nobody enables it redundantly.

## Verification

- Production run: 3 log lines on stdout, all valid single-line JSON, fields `label, level, message, name, stack, timestamp`, stack preserved as one field across 11 frames.
- Development run: output byte-identical in shape to before (colorized, `simple()`).
- File transports still written in both modes.
- `helm lint --strict`, 56 chart unit tests, typecheck and eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)