### PR TITLE
feat(export): add kml and kmz endpoints for Google Earth

### DIFF
--- a/commandLine.ts
+++ b/commandLine.ts
@@ -1,10 +1,20 @@
+import {getRelationKml, getRelationKmz} from './src/osm2kml.ts';
+import type {RelationExporter} from './src/relation.ts';
 import {getLogger} from './src/logger.ts';
-import {getRelation} from './src/osm2gpx.ts';
+import {getRelationGpx} from './src/osm2gpx.ts';
 import {hideBin} from 'yargs/helpers';
 import {writeFileSync} from 'fs';
 import yargs from 'yargs';
 
 const logger = getLogger('commandLine');
+
+const formats = ['gpx', 'kml', 'kmz'] as const;
+
+const exporters: Record<(typeof formats)[number], RelationExporter> = {
+  gpx: getRelationGpx,
+  kml: getRelationKml,
+  kmz: getRelationKmz,
+};
 
 await yargs(hideBin(process.argv))
   .usage('Usage: $0 <command> [options]')
@@ -12,19 +22,35 @@ await yargs(hideBin(process.argv))
     'node $0 getRelation 282071',
     'Exports the Israel National Trail into a gpx file',
   )
+  .example(
+    'node $0 getRelation 282071 -f kmz',
+    'Exports the same trail as a Google Earth kmz file',
+  )
   .command({
     command: 'getRelation <relationId>',
-    describe: 'Exports the relation to a gpx file',
+    describe: 'Exports the relation to a gpx, kml or kmz file',
+    /*
+     * Declared here rather than in the global `.options()` block below, which
+     * yargs applies after the command and so leaves untyped in `argv` — the
+     * one option whose value is used as a lookup key needs its union type.
+     */
     builder: (command) =>
-      command.positional('relationId', {
-        describe: 'Open Street Maps Relation Id to export',
-        type: 'number',
-        demandOption: true,
-      }),
+      command
+        .positional('relationId', {
+          describe: 'Open Street Maps Relation Id to export',
+          type: 'number',
+          demandOption: true,
+        })
+        .option('format', {
+          alias: 'f',
+          choices: formats,
+          default: 'gpx' as const,
+          describe: 'The output format',
+        }),
     async handler(argv) {
       try {
-        const {fileName, gpx} = await getRelation(argv);
-        writeFileSync(fileName, gpx);
+        const {fileName, body} = await exporters[argv.format](argv);
+        writeFileSync(fileName, body);
         logger.info(`Done writing file "${fileName}"`);
       } catch (error) {
         logger.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
+        "@placemarkio/tokml": "^0.3.9",
         "express": "^5.2.1",
         "geodesy": "^2.4.0",
         "gpx": "github:kchapelier/gpx",
@@ -18,7 +19,8 @@
         "prom-client": "^15.1.3",
         "slug": "^12.0.0",
         "winston": "^3.19.0",
-        "yargs": "^18.0.0"
+        "yargs": "^18.0.0",
+        "yazl": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -30,6 +32,7 @@
         "@types/slug": "^5.0.9",
         "@types/universal-analytics": "^0.4.8",
         "@types/yargs": "^17.0.35",
+        "@types/yazl": "^3.3.1",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript/native": "npm:typescript@~7.0.0",
         "chai": "^6.2.2",
@@ -311,6 +314,12 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@placemarkio/tokml": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@placemarkio/tokml/-/tokml-0.3.9.tgz",
+      "integrity": "sha512-LjD/rzPWF/0gY2tCoS4IPLQZ3/DqxzCmI3/V+dmXdWuZmyi3UIhHgxVfJ//bopxSjWHuGwY/qu4iyuNM+xluug==",
+      "license": "MIT"
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -497,6 +506,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.67.0",
@@ -1297,6 +1316,15 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4501,6 +4529,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/slug": "^5.0.9",
     "@types/universal-analytics": "^0.4.8",
     "@types/yargs": "^17.0.35",
+    "@types/yazl": "^3.3.1",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript/native": "npm:typescript@~7.0.0",
     "chai": "^6.2.2",
@@ -40,6 +41,7 @@
     "typescript-eslint": "^8.67.0"
   },
   "dependencies": {
+    "@placemarkio/tokml": "^0.3.9",
     "express": "^5.2.1",
     "geodesy": "^2.4.0",
     "gpx": "github:kchapelier/gpx",
@@ -49,7 +51,8 @@
     "prom-client": "^15.1.3",
     "slug": "^12.0.0",
     "winston": "^3.19.0",
-    "yargs": "^18.0.0"
+    "yargs": "^18.0.0",
+    "yazl": "^3.3.1"
   },
   "overrides": {
     "@mapbox/geojson-rewind": "^0.5.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,10 @@
-import {BadRequestError, getRelation, parseRelationRequest} from './osm2gpx.ts';
+import {BadRequestError, parseRelationRequest} from './relation.ts';
 import express, {type ErrorRequestHandler, type RequestHandler} from 'express';
+import {getRelationKml, getRelationKmz} from './osm2kml.ts';
 import {metricsMiddleware, startMetricsServer} from './metrics.ts';
+import type {RelationExporter} from './relation.ts';
 import {getLogger} from './logger.ts';
+import {getRelationGpx} from './osm2gpx.ts';
 import slug from 'slug';
 
 const app = express();
@@ -10,35 +13,43 @@ const logger = getLogger('app');
 
 slug.defaults.mode = 'rfc3986';
 
-const handler: RequestHandler<Record<string, never>, string> = async (
-  req,
-  res,
-) => {
-  const request = parseRelationRequest(req.query);
-  const {relationId} = request;
-  logger.info(`creating gpx - ${relationId}`);
-  logger.profile(relationId);
-  try {
-    const {fileName, gpx} = await getRelation(request);
-    const safeFileName = encodeURI(
-      slug(fileName, {
-        replacement: ' ',
-        symbols: false,
-        remove: null,
-        lower: false,
-        charmap: slug.charmap,
-        multicharmap: slug.multicharmap,
-      }),
-    );
-    res.set({
-      'Content-Disposition': `attachment; filename="${safeFileName}"`,
-      'Content-Type': 'application/xml',
-    });
-    res.send(gpx);
-  } finally {
+/*
+ * A route per format rather than a `format` query param, so the URL a user
+ * bookmarks or pastes says what it hands back and `metricsMiddleware` splits
+ * the latency histogram by format for free — the route pattern is already its
+ * label.
+ */
+function createHandler(
+  format: string,
+  getRelation: RelationExporter,
+): RequestHandler<Record<string, never>> {
+  return async (req, res) => {
+    const request = parseRelationRequest(req.query);
+    const {relationId} = request;
+    logger.info(`creating ${format} - ${relationId}`);
     logger.profile(relationId);
-  }
-};
+    try {
+      const {fileName, contentType, body} = await getRelation(request);
+      const safeFileName = encodeURI(
+        slug(fileName, {
+          replacement: ' ',
+          symbols: false,
+          remove: null,
+          lower: false,
+          charmap: slug.charmap,
+          multicharmap: slug.multicharmap,
+        }),
+      );
+      res.set({
+        'Content-Disposition': `attachment; filename="${safeFileName}"`,
+        'Content-Type': contentType,
+      });
+      res.send(body);
+    } finally {
+      logger.profile(relationId);
+    }
+  };
+}
 
 /*
  * Express 5 forwards rejected handler promises here, so `parseRelationRequest`
@@ -67,10 +78,14 @@ const errorHandler: ErrorRequestHandler = (error, req, res, next) => {
  *INT - http://localhost:3000/osm2gpx?relationId=282071&markerDiff=1609.34
  *JMT - http://localhost:3000/osm2gpx?relationId=1244828&markerDiff=1609.34&reverse=1&segmentLimit=0
  * 6148296 - ramon crater
+ *http://localhost:3000/osm2kml?relationId=282071
+ *http://localhost:3000/osm2kmz?relationId=282071
  */
 // Ahead of the routes, so unmatched paths and error responses are counted too.
 app.use(metricsMiddleware);
-app.get('/osm2gpx', handler);
+app.get('/osm2gpx', createHandler('gpx', getRelationGpx));
+app.get('/osm2kml', createHandler('kml', getRelationKml));
+app.get('/osm2kmz', createHandler('kmz', getRelationKmz));
 app.use(errorHandler);
 
 const port = process.env.PORT || 3000;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -37,11 +37,16 @@ const overpassRequestDuration = new Histogram({
   registers: [registry],
 });
 
-const gpxSizeBytes = new Histogram({
-  name: 'osmexport_gpx_size_bytes',
-  help: 'Size of generated GPX documents',
-  // The Israel National Trail, one of the largest relations exported, is ~2MB.
-  buckets: [10e3, 100e3, 500e3, 2e6, 8e6, 32e6],
+const exportSizeBytes = new Histogram({
+  name: 'osmexport_export_size_bytes',
+  help: 'Size of generated export documents, by format',
+  labelNames: ['format'],
+  /*
+   * The Israel National Trail, one of the largest relations exported, is ~2MB
+   * of GPX. The low buckets are there for KMZ, which deflates the same relation
+   * by roughly an order of magnitude.
+   */
+  buckets: [1e3, 10e3, 100e3, 500e3, 2e6, 8e6, 32e6],
   registers: [registry],
 });
 
@@ -99,9 +104,9 @@ export function observeRelationPoints(count: number): void {
   relationPoints.observe(count);
 }
 
-export function observeGpxSize(gpx: string): void {
-  // Byte length, not string length — GPX carries non-ASCII relation names.
-  gpxSizeBytes.observe(Buffer.byteLength(gpx));
+export function observeExportSize(format: string, body: string | Buffer): void {
+  // Byte length, not string length — exports carry non-ASCII relation names.
+  exportSizeBytes.observe({format}, Buffer.byteLength(body));
 }
 
 /*

--- a/src/osm2gpx.ts
+++ b/src/osm2gpx.ts
@@ -1,111 +1,16 @@
 import type {
-  Feature,
-  LineString,
-  MultiLineString,
-  Point,
-  Position,
-} from 'geojson';
-import {observeGpxSize, observeRelationPoints} from './metrics.ts';
-import LatLon from 'geodesy/latlon-ellipsoidal-vincenty.js';
+  ExportResult,
+  MarkerFeature,
+  RelationFeature,
+  RelationRequest,
+} from './relation.ts';
+import {getRelationData, waysOf} from './relation.ts';
 import _ from 'lodash';
-import {getFullRelation} from './osm/osmWrapper.ts';
 import {getLogger} from './logger.ts';
 import gpx from 'gpx';
-import moment from 'moment';
+import {observeExportSize} from './metrics.ts';
 
 const logger = getLogger('osm2gpx');
-
-type RelationProps = {
-  name: string;
-  'name:en'?: string;
-  timestamp: string;
-};
-
-type RelationFeature = Feature<LineString | MultiLineString, RelationProps>;
-
-type MarkerFeature = Feature<Point, {marker: number}>;
-
-export interface RelationRequest {
-  relationId: number;
-  segmentLimit?: number;
-  markerDiff?: number;
-  reverse?: boolean;
-}
-
-export interface RelationResponse {
-  fileName: string;
-  gpx: string;
-}
-
-export class BadRequestError extends Error {
-  name = 'BadRequestError';
-}
-
-function parseRelationId(value: unknown): number {
-  const parsed =
-    typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : NaN;
-  if (!Number.isSafeInteger(parsed)) {
-    throw new BadRequestError('"relationId" must be a numeric OSM relation id');
-  }
-
-  return parsed;
-}
-
-function parseNonNegativeNumber(value: unknown, name: string): number {
-  const parsed =
-    typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN;
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new BadRequestError(`"${name}" must be a non-negative number`);
-  }
-
-  return parsed;
-}
-
-function parseBoolean(value: unknown, name: string): boolean {
-  if (value === '1' || value === 'true') {
-    return true;
-  }
-
-  if (value === '0' || value === 'false') {
-    return false;
-  }
-
-  throw new BadRequestError(`"${name}" must be "0", "1", "true" or "false"`);
-}
-
-/*
- * Narrows an untrusted query string object into a `RelationRequest`. Absent
- * optional params are left off so `getRelation` keeps owning their defaults.
- */
-export function parseRelationRequest(
-  query: Record<string, unknown>,
-): RelationRequest {
-  const request: RelationRequest = {
-    relationId: parseRelationId(query.relationId),
-  };
-  if (typeof query.segmentLimit !== 'undefined') {
-    request.segmentLimit = parseNonNegativeNumber(
-      query.segmentLimit,
-      'segmentLimit',
-    );
-  }
-
-  if (typeof query.markerDiff !== 'undefined') {
-    request.markerDiff = parseNonNegativeNumber(query.markerDiff, 'markerDiff');
-  }
-
-  if (typeof query.reverse !== 'undefined') {
-    request.reverse = parseBoolean(query.reverse, 'reverse');
-  }
-
-  return request;
-}
-
-function waysOf(geometry: LineString | MultiLineString): Position[][] {
-  return geometry.type === 'LineString'
-    ? [geometry.coordinates]
-    : geometry.coordinates;
-}
 
 function createGpx(
   relation: RelationFeature,
@@ -156,95 +61,17 @@ function createGpx(
   return builder.xml();
 }
 
-function createMarkerFeature(
-  lat: number,
-  lon: number,
-  marker: number,
-): MarkerFeature {
-  logger.verbose(`Creating marker, (${lat}, ${lon}) - ${marker}`);
-  return {
-    type: 'Feature',
-    properties: {
-      marker,
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [lon, lat],
-    },
-  };
-}
-
-function addMarkers(
-  relation: RelationFeature,
-  markerDiff: number,
-): MarkerFeature[] {
-  const markers: MarkerFeature[] = [];
-  let prevDistance = 0;
-  let prevMarker = 0;
-  let prevLatLon: LatLon | null = null;
-  waysOf(relation.geometry).forEach((way) => {
-    way.forEach(([lon, lat]) => {
-      if (prevLatLon) {
-        const latLon = new LatLon(lat, lon);
-        const distance = prevDistance + prevLatLon.distanceTo(latLon);
-        const marker = Math.floor(distance / markerDiff);
-        if (prevMarker < marker) {
-          const distanceToNextMarker = marker * markerDiff - prevDistance;
-          const bearing = prevLatLon.initialBearingTo(latLon);
-          const {lat: markerLat, lon: markerLon} = prevLatLon.destinationPoint(
-            distanceToNextMarker,
-            bearing,
-          );
-          markers.push(createMarkerFeature(markerLat, markerLon, marker));
-          prevMarker = marker;
-        }
-
-        prevDistance = distance;
-        prevLatLon = latLon;
-      } else {
-        markers.push(createMarkerFeature(lat, lon, 0));
-        prevLatLon = new LatLon(lat, lon);
-      }
-    });
-  });
-  return markers;
-}
-
-export async function getRelation(
+export async function getRelationGpx(
   request: RelationRequest,
-): Promise<RelationResponse> {
-  const {relationId, segmentLimit = 0, markerDiff = 1000, reverse} = request;
-  const geoJson = await getFullRelation(relationId);
-  const relation = geoJson.features.find(
-    (f): f is RelationFeature =>
-      typeof f.id === 'string' && f.id.startsWith('relation'),
-  );
-  if (!relation) {
-    throw new Error(`No relation feature found for ${relationId}`);
-  }
-
-  if (reverse) {
-    relation.geometry.coordinates.reverse();
-  }
-
-  /*
-   * Point count is the input size that actually drives how long the rest of
-   * this takes — `addMarkers` runs a Vincenty solution per point — so it is
-   * what makes a slow export explainable rather than just slow.
-   */
-  observeRelationPoints(
-    waysOf(relation.geometry).reduce((total, way) => total + way.length, 0),
-  );
-  const markers = addMarkers(relation, markerDiff);
-  const {
-    properties: {name, 'name:en': nameEn = name, timestamp},
-  } = relation;
-  const fileName = `${nameEn}-${moment(timestamp).format('YY-MM-DD')}.gpx`;
+): Promise<ExportResult> {
+  const {segmentLimit = 0} = request;
+  const {relation, markers, baseFileName} = await getRelationData(request);
   // Not named `gpx`; that would shadow the builder module imported above.
   const gpxXml = createGpx(relation, markers, segmentLimit);
-  observeGpxSize(gpxXml);
+  observeExportSize('gpx', gpxXml);
   return {
-    fileName,
-    gpx: gpxXml,
+    fileName: `${baseFileName}.gpx`,
+    contentType: 'application/xml',
+    body: gpxXml,
   };
 }

--- a/src/osm2kml.ts
+++ b/src/osm2kml.ts
@@ -1,0 +1,156 @@
+import type {
+  ExportResult,
+  MarkerFeature,
+  RelationFeature,
+  RelationRequest,
+} from './relation.ts';
+import type {Feature, LineString, MultiLineString, Point} from 'geojson';
+import {ZipFile} from 'yazl';
+import {foldersToKML} from '@placemarkio/tokml';
+import {getLogger} from './logger.ts';
+import {getRelationData} from './relation.ts';
+import {observeExportSize} from './metrics.ts';
+
+const logger = getLogger('osm2kml');
+
+/*
+ * `tokml` emits the bare `<kml>` element. Google Earth opens that happily, but
+ * the declaration is what tells every other consumer the bytes are UTF-8, and
+ * relation names routinely are not ASCII.
+ */
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n';
+
+/*
+ * KMZ is a zip whose entry point is a KML at the archive root. `doc.kml` is
+ * the conventional name, and Google Earth looks for a root-level `.kml`.
+ */
+const KMZ_ENTRY = 'doc.kml';
+
+type TrailFeature = Feature<
+  LineString | MultiLineString,
+  {name: string; description: string; timestamp: string}
+>;
+
+type KmlMarkerFeature = Feature<Point, {name: string}>;
+
+/*
+ * One Placemark for the whole relation rather than the per-way, per-segment
+ * split `createGpx` does: that split exists to stay under GPX consumers' track
+ * point limits, and Google Earth has no equivalent limit. A single placemark
+ * is also what makes the trail one clickable item in the sidebar instead of
+ * dozens. A `MultiLineString` relation becomes a `MultiGeometry`, so gaps in
+ * the relation still render as gaps.
+ */
+function createTrailFeature(
+  relation: RelationFeature,
+  name: string,
+): TrailFeature {
+  const {
+    geometry,
+    properties: {timestamp},
+  } = relation;
+  /*
+   * Rebuilt rather than passed through, because `tokml` turns a feature `id`
+   * into the Placemark's `id` attribute and osmtogeojson's ids look like
+   * `relation/282071` — not a valid XML name. Anything left in `properties`
+   * lands in `<ExtendedData>`, so only what is worth showing goes in.
+   */
+  return {
+    type: 'Feature',
+    properties: {
+      name,
+      description: 'Data extracted from OSM',
+      timestamp,
+    },
+    geometry,
+  };
+}
+
+function createKml(
+  relation: RelationFeature,
+  markers: MarkerFeature[],
+  name: string,
+): string {
+  logger.info(`Creating KML for ${relation.id}`);
+  const markerFeatures: KmlMarkerFeature[] = markers.map(
+    ({properties: {marker}, geometry}) => ({
+      type: 'Feature',
+      // `name` is the only property `tokml` renders as the placemark's label.
+      properties: {name: String(marker)},
+      geometry,
+    }),
+  );
+  /*
+   * Markers go in their own folder so they can be toggled off in one click;
+   * a 1,000km trail at the default 1km spacing is otherwise a sidebar of a
+   * thousand numbered pins sitting next to the trail itself.
+   */
+  const markerFolders = markerFeatures.length
+    ? [
+        {
+          type: 'folder',
+          meta: {name: 'Markers'},
+          children: markerFeatures,
+        },
+      ]
+    : [];
+  return (
+    XML_DECLARATION +
+    foldersToKML({
+      type: 'root',
+      children: [createTrailFeature(relation, name), ...markerFolders],
+    })
+  );
+}
+
+/*
+ * Yazl streams, and every caller here wants one buffer to hand to `res.send`
+ * or `writeFileSync`, so the stream is collected rather than plumbed through.
+ * A KMZ holds a single already-in-memory KML, so there is nothing to gain by
+ * streaming it and a chunked response would lose the `Content-Length`.
+ */
+function zipKml(kml: string, timestamp: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const zipFile = new ZipFile();
+    const chunks: Buffer[] = [];
+    zipFile.outputStream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    zipFile.outputStream.on('error', reject);
+    zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+    /*
+     * The relation's own timestamp, not `Date.now()`, so re-exporting an
+     * unchanged relation produces byte-identical output.
+     */
+    zipFile.addBuffer(Buffer.from(kml, 'utf8'), KMZ_ENTRY, {
+      mtime: new Date(timestamp),
+    });
+    zipFile.end();
+  });
+}
+
+export async function getRelationKml(
+  request: RelationRequest,
+): Promise<ExportResult> {
+  const {relation, markers, name, baseFileName} =
+    await getRelationData(request);
+  const kml = createKml(relation, markers, name);
+  observeExportSize('kml', kml);
+  return {
+    fileName: `${baseFileName}.kml`,
+    contentType: 'application/vnd.google-earth.kml+xml',
+    body: kml,
+  };
+}
+
+export async function getRelationKmz(
+  request: RelationRequest,
+): Promise<ExportResult> {
+  const {relation, markers, name, timestamp, baseFileName} =
+    await getRelationData(request);
+  const kmz = await zipKml(createKml(relation, markers, name), timestamp);
+  observeExportSize('kmz', kmz);
+  return {
+    fileName: `${baseFileName}.kmz`,
+    contentType: 'application/vnd.google-earth.kmz',
+    body: kmz,
+  };
+}

--- a/src/relation.ts
+++ b/src/relation.ts
@@ -1,0 +1,228 @@
+import type {
+  Feature,
+  LineString,
+  MultiLineString,
+  Point,
+  Position,
+} from 'geojson';
+import LatLon from 'geodesy/latlon-ellipsoidal-vincenty.js';
+import {getFullRelation} from './osm/osmWrapper.ts';
+import {getLogger} from './logger.ts';
+import moment from 'moment';
+import {observeRelationPoints} from './metrics.ts';
+
+const logger = getLogger('relation');
+
+type RelationProps = {
+  name: string;
+  'name:en'?: string;
+  timestamp: string;
+};
+
+export type RelationFeature = Feature<
+  LineString | MultiLineString,
+  RelationProps
+>;
+
+export type MarkerFeature = Feature<Point, {marker: number}>;
+
+export interface RelationRequest {
+  relationId: number;
+  segmentLimit?: number;
+  markerDiff?: number;
+  reverse?: boolean;
+}
+
+/*
+ * Everything the format modules need, and nothing format specific: fetching
+ * the relation and walking it for markers costs an Overpass round trip plus a
+ * Vincenty solution per point, so it happens once here rather than once per
+ * output format.
+ */
+export interface RelationData {
+  relation: RelationFeature;
+  markers: MarkerFeature[];
+  /*
+   * The English name where the relation carries one, since that is what the
+   * download is named after and `name` is often only in the local script.
+   */
+  name: string;
+  timestamp: string;
+  // Extension-less; each format module appends its own.
+  baseFileName: string;
+}
+
+export interface ExportResult {
+  fileName: string;
+  contentType: string;
+  body: string | Buffer;
+}
+
+export type RelationExporter = (
+  request: RelationRequest,
+) => Promise<ExportResult>;
+
+export class BadRequestError extends Error {
+  name = 'BadRequestError';
+}
+
+function parseRelationId(value: unknown): number {
+  const parsed =
+    typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : NaN;
+  if (!Number.isSafeInteger(parsed)) {
+    throw new BadRequestError('"relationId" must be a numeric OSM relation id');
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeNumber(value: unknown, name: string): number {
+  const parsed =
+    typeof value === 'string' && value.trim() !== '' ? Number(value) : NaN;
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new BadRequestError(`"${name}" must be a non-negative number`);
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value: unknown, name: string): boolean {
+  if (value === '1' || value === 'true') {
+    return true;
+  }
+
+  if (value === '0' || value === 'false') {
+    return false;
+  }
+
+  throw new BadRequestError(`"${name}" must be "0", "1", "true" or "false"`);
+}
+
+/*
+ * Narrows an untrusted query string object into a `RelationRequest`. Absent
+ * optional params are left off so the exporters keep owning their defaults.
+ * `segmentLimit` is accepted on every route even though only GPX honours it,
+ * so that a bookmarked URL keeps working when the format after `/osm2` is
+ * swapped.
+ */
+export function parseRelationRequest(
+  query: Record<string, unknown>,
+): RelationRequest {
+  const request: RelationRequest = {
+    relationId: parseRelationId(query.relationId),
+  };
+  if (typeof query.segmentLimit !== 'undefined') {
+    request.segmentLimit = parseNonNegativeNumber(
+      query.segmentLimit,
+      'segmentLimit',
+    );
+  }
+
+  if (typeof query.markerDiff !== 'undefined') {
+    request.markerDiff = parseNonNegativeNumber(query.markerDiff, 'markerDiff');
+  }
+
+  if (typeof query.reverse !== 'undefined') {
+    request.reverse = parseBoolean(query.reverse, 'reverse');
+  }
+
+  return request;
+}
+
+export function waysOf(geometry: LineString | MultiLineString): Position[][] {
+  return geometry.type === 'LineString'
+    ? [geometry.coordinates]
+    : geometry.coordinates;
+}
+
+function createMarkerFeature(
+  lat: number,
+  lon: number,
+  marker: number,
+): MarkerFeature {
+  logger.verbose(`Creating marker, (${lat}, ${lon}) - ${marker}`);
+  return {
+    type: 'Feature',
+    properties: {
+      marker,
+    },
+    geometry: {
+      type: 'Point',
+      coordinates: [lon, lat],
+    },
+  };
+}
+
+function addMarkers(
+  relation: RelationFeature,
+  markerDiff: number,
+): MarkerFeature[] {
+  const markers: MarkerFeature[] = [];
+  let prevDistance = 0;
+  let prevMarker = 0;
+  let prevLatLon: LatLon | null = null;
+  waysOf(relation.geometry).forEach((way) => {
+    way.forEach(([lon, lat]) => {
+      if (prevLatLon) {
+        const latLon = new LatLon(lat, lon);
+        const distance = prevDistance + prevLatLon.distanceTo(latLon);
+        const marker = Math.floor(distance / markerDiff);
+        if (prevMarker < marker) {
+          const distanceToNextMarker = marker * markerDiff - prevDistance;
+          const bearing = prevLatLon.initialBearingTo(latLon);
+          const {lat: markerLat, lon: markerLon} = prevLatLon.destinationPoint(
+            distanceToNextMarker,
+            bearing,
+          );
+          markers.push(createMarkerFeature(markerLat, markerLon, marker));
+          prevMarker = marker;
+        }
+
+        prevDistance = distance;
+        prevLatLon = latLon;
+      } else {
+        markers.push(createMarkerFeature(lat, lon, 0));
+        prevLatLon = new LatLon(lat, lon);
+      }
+    });
+  });
+  return markers;
+}
+
+export async function getRelationData(
+  request: RelationRequest,
+): Promise<RelationData> {
+  const {relationId, markerDiff = 1000, reverse} = request;
+  const geoJson = await getFullRelation(relationId);
+  const relation = geoJson.features.find(
+    (f): f is RelationFeature =>
+      typeof f.id === 'string' && f.id.startsWith('relation'),
+  );
+  if (!relation) {
+    throw new Error(`No relation feature found for ${relationId}`);
+  }
+
+  if (reverse) {
+    relation.geometry.coordinates.reverse();
+  }
+
+  /*
+   * Point count is the input size that actually drives how long the rest of
+   * this takes — `addMarkers` runs a Vincenty solution per point — so it is
+   * what makes a slow export explainable rather than just slow.
+   */
+  observeRelationPoints(
+    waysOf(relation.geometry).reduce((total, way) => total + way.length, 0),
+  );
+  const markers = addMarkers(relation, markerDiff);
+  const {
+    properties: {name, 'name:en': nameEn = name, timestamp},
+  } = relation;
+  return {
+    relation,
+    markers,
+    name: nameEn,
+    timestamp,
+    baseFileName: `${nameEn}-${moment(timestamp).format('YY-MM-DD')}`,
+  };
+}


### PR DESCRIPTION
Adds `/osm2kml` and `/osm2kmz` alongside `/osm2gpx`. All three take the same `relationId`, `markerDiff` and `reverse` params.

A route per format rather than a `format` query param, so a bookmarked URL says what it hands back, and `metricsMiddleware` splits the latency histogram by format for free — the route pattern is already its label.

## Structure

The fetch, marker walk and file naming move out of `osm2gpx.ts` into a new `src/relation.ts`, so the Overpass round trip and the per-point Vincenty solution are written once. `osm2gpx.ts` is now just the GPX serializer and `src/osm2kml.ts` is the new one; each exporter returns `{fileName, contentType, body}` and `app.ts` has a `createHandler(format, exporter)` factory the three routes share.

The CLI gains `-f/--format` rather than a fourth command, since `getRelation` was already the only command and the format is an output detail.

## KML shape

One Placemark for the whole relation — a `MultiLineString` becomes a `MultiGeometry`, so relation gaps still render as gaps — plus a `Markers` folder that can be toggled off in one click. No per-way/per-segment split: that exists only for GPX track-point limits, and 147 pins next to a hundred way placemarks would be an unusable sidebar. The relation `id` is dropped when rebuilding the feature, because tokml turns it into an `id` attribute and `relation/6148296` is not a valid XML name.

`@placemarkio/tokml` has no simplestyle support, so the trail renders in Google Earth's default line. Adding a `<Style>` is a follow-up if we want a coloured trail.

## KMZ

`yazl` (1 transitive dep, vs jszip's 4 including `readable-stream` 2.x). Single `doc.kml` entry, mtime taken from the relation timestamp so re-exporting unchanged data is byte-identical.

## Operator note

`osmexport_gpx_size_bytes` is now `osmexport_export_size_bytes{format="gpx|kml|kmz"}`, with a 1KB bucket added for KMZ. Any dashboard on the old name needs updating. Not marked as a breaking change since it is an internal metric rather than the app's interface — say the word if it should trigger a major bump.

## Testing

Verified against relation 6148296 (Ramon crater), CLI and HTTP, all three formats:

- KML structure as described; `Content-Type: application/vnd.google-earth.kml+xml`
- KMZ passes `zipfile.testzip()`, 103KB KML to 31KB archive; `Content-Type: application/vnd.google-earth.kmz` with no bogus charset appended
- GPX byte-for-byte the same path as before
- `osmexport_export_size_bytes_count` reports all three format labels

Lint and typecheck clean. Not opened in Google Earth itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)