### PR TITLE
fix(osm): fetch relations from the OSM API instead of Overpass

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -9,7 +9,7 @@ const logger = getLogger('metrics');
  * module from the CLI entrypoint cannot collide with anything else and tests
  * can build their own. `collectDefaultMetrics` adds the process and Node
  * runtime series — event loop lag, GC pauses, heap and handle counts — which
- * are the only signals that distinguish "Overpass is slow" from "we are".
+ * are the only signals that distinguish "the OSM API is slow" from "we are".
  */
 export const registry = new Registry();
 
@@ -17,9 +17,9 @@ collectDefaultMetrics({register: registry});
 
 /*
  * Every duration bucket set below is in seconds and skewed long on purpose.
- * A request here is dominated by one or two Overpass round trips, so the
- * library defaults (which top out at 10s) would pile most real traffic into
- * +Inf and make the histogram unable to answer anything.
+ * A request here is dominated by one OSM API round trip, so the library
+ * defaults (which top out at 10s) would pile most real traffic into +Inf and
+ * make the histogram unable to answer anything.
  */
 const httpRequestDuration = new Histogram({
   name: 'osmexport_http_request_duration_seconds',
@@ -29,11 +29,12 @@ const httpRequestDuration = new Histogram({
   registers: [registry],
 });
 
-const overpassRequestDuration = new Histogram({
-  name: 'osmexport_overpass_request_duration_seconds',
-  help: 'Duration of outbound Overpass API queries, by query kind and outcome',
+const osmApiRequestDuration = new Histogram({
+  name: 'osmexport_osm_api_request_duration_seconds',
+  help: 'Duration of outbound OSM API requests, by query kind and outcome',
   labelNames: ['query', 'outcome'],
-  buckets: [0.5, 1, 2.5, 5, 10, 20, 30, 60],
+  // Lower buckets than the Overpass queries this replaced, which it outruns.
+  buckets: [0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60],
   registers: [registry],
 });
 
@@ -85,11 +86,11 @@ export const metricsMiddleware: RequestHandler = (req, res, next) => {
   next();
 };
 
-export async function observeOverpassQuery<T>(
+export async function observeOsmApiQuery<T>(
   query: string,
   run: () => Promise<T>,
 ): Promise<T> {
-  const stop = overpassRequestDuration.startTimer({query});
+  const stop = osmApiRequestDuration.startTimer({query});
   try {
     const result = await run();
     stop({outcome: 'success'});

--- a/src/osm/osmApi.ts
+++ b/src/osm/osmApi.ts
@@ -1,32 +1,59 @@
-import {observeOverpassQuery} from '../metrics.ts';
+import {observeOsmApiQuery} from '../metrics.ts';
 
-interface OverpassError {
-  error?: string;
+const API_BASE = 'https://api.openstreetmap.org/api/0.6';
+
+/*
+ * Enough to carry the API's own sentence, short enough that a proxy's HTML
+ * error page cannot flood the log line it ends up on.
+ */
+const MAX_ERROR_DETAIL = 500;
+
+/*
+ * Failures arrive as a plain text body, and sometimes in an `Error` response
+ * header instead — never as JSON, which is why parsing the body as JSON used
+ * to leave every failure indistinguishable from every other one. Whitespace is
+ * collapsed so a multi-line body stays a single log line.
+ *
+ * Falling back on emptiness rather than absence: the API answers a deleted
+ * relation with an `Error` header that is present but blank, which `??` would
+ * take for a message and stop looking.
+ */
+async function describeFailure(response: Response): Promise<string> {
+  const header = response.headers.get('Error')?.trim() ?? '';
+  /*
+   * Only `text/plain`, which is what the API itself answers with. A path it
+   * does not route at all falls through to the Rails frontend and comes back
+   * as a full HTML page, and half a kilobyte of markup in the log line says
+   * strictly less than the status code does.
+   */
+  const isPlainText = response.headers
+    .get('Content-Type')
+    ?.startsWith('text/plain');
+  const body = header || !isPlainText ? '' : await response.text();
+  const detail = (header || body).replace(/\s+/g, ' ').trim();
+  const status = `${response.status} ${response.statusText}`.trim();
+  return detail
+    ? `Request failed with status ${status} - ${detail.slice(0, MAX_ERROR_DETAIL)}`
+    : `Request failed with status ${status}`;
 }
 
 /*
- * `kind` is what labels the metric — the query text itself embeds the relation
- * id, so using it would mint a new series per relation exported.
+ * `kind` is what labels the metric — the path embeds the relation id, so using
+ * it would mint a new series per relation exported.
  */
-function overpassQuery(kind: string, query: string) {
-  return observeOverpassQuery(kind, async () => {
-    const body = `[out:json][timeout:25];${query}`;
-    const result = await fetch('http://overpass-api.de/api/interpreter', {
-      method: 'POST',
-      body,
+function osmApiRequest(kind: string, path: string) {
+  return observeOsmApiQuery(kind, async () => {
+    const result = await fetch(`${API_BASE}${path}`, {
       /*
-       * Overpass rejects undici's default `User-Agent: node` with a 406.
-       * node-fetch used to send its own UA, so this only surfaced once it went.
+       * Kept from the Overpass client, which rejected undici's default
+       * `User-Agent: node` with a 406. The editing API serves that UA fine,
+       * but its usage policy asks for an identifying one and blocks by agent
+       * when it has to, so this stays.
        */
       headers: {'User-Agent': 'OSMExport/2.0.1'},
     });
     if (!result.ok) {
-      const errorBody = (await result
-        .json()
-        .catch(() => ({}))) as OverpassError;
-      throw new Error(
-        errorBody.error || `Request failed with status ${result.status}`,
-      );
+      throw new Error(await describeFailure(result));
     }
 
     return result.json();
@@ -34,29 +61,16 @@ function overpassQuery(kind: string, query: string) {
 }
 
 export function fetchRelation(relationId: number) {
-  return overpassQuery(
-    'relation',
-    `
-    relation(${relationId});
-    (._;>;);
-    out body meta;
-  `,
-  );
-}
-
-export function fetchNodesInRelation(relationId: number) {
-  return overpassQuery(
-    'nodes',
-    `
-    relation(${relationId}) -> .r;
-    way(r.r) -> .w;
-    node(w.w) -> .n;
-    (
-      .n;
-      .w;
-      .r;
-    )->.all;
-    .all out body meta;
-  `,
-  );
+  /*
+   * `/full` returns the relation, its member ways, and every node of those
+   * ways — precisely what the Overpass `(._;>;)` recursion this replaces
+   * produced, in the same OSM JSON shape `osmtogeojson` consumes, and with the
+   * `meta` attributes the export needs for its timestamp.
+   *
+   * Overpass was answering this with 504s
+   * (`Dispatcher_Client::request_read_and_idx::timeout`): its public instance
+   * allows two concurrent slots per IP and the query never got one. The
+   * editing API has no such queue, and serves the same relation in seconds.
+   */
+  return osmApiRequest('relation', `/relation/${relationId}/full.json`);
 }

--- a/src/osm/osmWrapper.ts
+++ b/src/osm/osmWrapper.ts
@@ -1,5 +1,5 @@
 import type {FeatureCollection, GeometryObject} from 'geojson';
-import {fetchNodesInRelation, fetchRelation} from './osmApi.ts';
+import {fetchRelation} from './osmApi.ts';
 import {getLogger} from '../logger.ts';
 import osmtogeojson from 'osmtogeojson';
 
@@ -14,18 +14,6 @@ export async function getFullRelation(
   return osmtogeojson(osmJson, {
     uninterestingTags() {
       return filter;
-    },
-  });
-}
-
-export async function getRelationNodes(
-  relationId: number,
-): Promise<FeatureCollection<GeometryObject>> {
-  logger.verbose(`Getting nodes for relation '${relationId}'`);
-  const osmJson = await fetchNodesInRelation(relationId);
-  return osmtogeojson(osmJson, {
-    uninterestingTags() {
-      return true;
     },
   });
 }


### PR DESCRIPTION
Rebased onto #544 now that it has merged. Both touch `src/metrics.ts`, in separate hunks.

## Why

Exports have been failing with 504s. The response body says why:

> `runtime error: ... Dispatcher_Client::request_read_and_idx::timeout. The server is probably too busy to handle your request.`

That is the *dispatcher* timeout — the query never got a database read slot. `overpass-api.de/api/status` confirms it is congestion, not throttling:

```
Rate limit: 2
2 slots available now.
```

Both slots free, no penalty. Throttling would be a 429 anyway. There is no quota to raise: the limit is a fixed 2 concurrent slots per IP with no paid tier. I measured the `overpass.kumi.systems` mirror as an escape and it took **148 seconds** on the Israel National Trail, so that is not a fix either.

## What

`/api/0.6/relation/{id}/full.json` returns the relation, its member ways, and every node of those ways — precisely what the `(._;>;)` recursion produced, in the same OSM JSON shape `osmtogeojson` consumes, with the `meta` attributes the export needs for its timestamp. It is also the endpoint meant for this, rather than a general query engine asked for one relation.

| | relation 282071 | relation 6148296 |
|---|---|---|
| Overpass | 504, or 200 after ~30s | 200 after 6.7s |
| OSM API | **200 after 3.5s** | **200 after 0.6s** |

Also drops `fetchNodesInRelation`/`getRelationNodes` — nothing called it, and it existed only to run a second Overpass query. Shout if you were keeping it for something.

## Error surfacing

Both Overpass and the OSM API report failures as text, never as JSON — so `result.json()` always threw and the `.catch(() => ({}))` behind it reduced every failure to a bare status code. That is why the 504s above needed a manual `curl` to explain.

Messages now come from the `Error` response header or a `text/plain` body, whitespace collapsed to a single log line and capped at 500 characters. Two wrinkles found while testing:

- The API answers a deleted relation with an `Error` header that is **present but blank**, so `??` would take it for a message and never read the body. Falls back on emptiness rather than absence.
- An unrouted path falls through to the Rails frontend as a full HTML page. Only `text/plain` is read; half a kilobyte of markup says strictly less than the status code does.

## Testing

**Equivalence** — fetched both relations from both sources at the same moment, same relation version, and compared the assembled geometry through `osmtogeojson`:

- `6148296`: MultiLineString, parts `[3604, 37, 263]`, 3904 points — **identical**
- `282071`: LineString, 41,689 points, same direction — **identical**

A first comparison against the kumi mirror showed 41,694 points and a reversed trail; that mirror was serving relation v2399 from 2026-06-26 against the API's v2407 from 2026-08-03, i.e. staleness, not a source difference. The checked-in `Israel National Trail-26-08-03.gpx` also differs in direction, but it predates current member-way data — the same-moment A/B above is the controlled comparison.

**Error paths** — exercised through the real module with `fetch` stubbed:

| case | message |
|---|---|
| `text/plain` body | `Request failed with status 400 - The maximum bbox size is 0.250000, and your request was too large. Either request a smaller area, or use planet.osm` |
| `Error` header present | `Request failed with status 509 - Bandwidth limit exceeded` |
| blank `Error` header | `Request failed with status 410 - Gone` |
| HTML page | `Request failed with status 404` |
| 2000-char body | truncated at 500 |

Live 404 (missing relation) and 410 (relation 7, deleted) both come back clean; the API sends no detail for either, so the status is all there is.

**Combined with #544** — after the rebase, all three routes serve relation 282071, the one Overpass was 504ing on:

| route | status | time | size |
|---|---|---|---|
| `/osm2gpx` | 200 | 2.0s | 2.14 MB |
| `/osm2kml` | 200 | 1.6s | 0.98 MB |
| `/osm2kmz` | 200 | 1.6s | 0.30 MB |

`osmexport_osm_api_request_duration_seconds` and `osmexport_export_size_bytes{format}` both report correctly side by side. Lint and typecheck clean.

## Follow-up, not in this PR

A missing relation now yields a 404 from the API and still surfaces to the client as a 500. Mapping it to a 404 would need a new error class alongside `BadRequestError` — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
